### PR TITLE
Lesson 03 / BasicChat-01MEAI - Missing using stmt for System.Text and fixing spelling error in comment.

### DIFF
--- a/03-CoreGenerativeAITechniques/src/BasicChat-01MEAI/Program.cs
+++ b/03-CoreGenerativeAITechniques/src/BasicChat-01MEAI/Program.cs
@@ -2,6 +2,7 @@
 using Azure.AI.Inference;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Configuration;
+using System.Text;
 
 var githubToken = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
 if(string.IsNullOrEmpty(githubToken))
@@ -26,5 +27,5 @@ prompt.AppendLine("I found this product based on the other reviews. It worked fo
 // send the prompt to the model and wait for the text completion
 var response = await client.CompleteAsync(prompt.ToString());
 
-// display the repsonse
+// display the response
 Console.WriteLine(response.Message);


### PR DESCRIPTION
* project would not run in codespaces, error message: The type or namespace name 'StringBuilder' could not be found (are you missing a using directive or an assembly reference?). Added using stmt for System.Text and error message went away. 
* fixed one misspelling in last code comment