### PR TITLE
Add new projects to showcase the use of o3-mini model with SK

### DIFF
--- a/03-CoreGenerativeAITechniques/src/CoreGenerativeAITechniques.sln
+++ b/03-CoreGenerativeAITechniques/src/CoreGenerativeAITechniques.sln
@@ -53,6 +53,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MEAIFunctions", "MEAIFuncti
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MEAIFunctionsOllama", "MEAIFunctionsOllama\MEAIFunctionsOllama.csproj", "{B0A1DF75-4625-45D5-87B0-29F7290F63E1}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "07 Reasoning", "07 Reasoning", "{301F771F-CBE6-4D34-A24A-02F7DE5463DC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReasoningLabs-01-SK", "ReasoningLabs-01-SK\ReasoningLabs-01-SK.csproj", "{7274D8C3-EC9B-4D54-B472-CBE1E44C39AC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -135,6 +139,10 @@ Global
 		{B0A1DF75-4625-45D5-87B0-29F7290F63E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B0A1DF75-4625-45D5-87B0-29F7290F63E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B0A1DF75-4625-45D5-87B0-29F7290F63E1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7274D8C3-EC9B-4D54-B472-CBE1E44C39AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7274D8C3-EC9B-4D54-B472-CBE1E44C39AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7274D8C3-EC9B-4D54-B472-CBE1E44C39AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7274D8C3-EC9B-4D54-B472-CBE1E44C39AC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -159,6 +167,7 @@ Global
 		{35DF7A10-DE5D-41CA-9940-F93FA1385534} = {B5980212-D3CF-4A46-94EA-3B22EFAD1257}
 		{33CE094D-6C79-4151-87D5-8D49A9982328} = {F5798C6F-98D6-4411-A5F0-F928CBA64095}
 		{B0A1DF75-4625-45D5-87B0-29F7290F63E1} = {F5798C6F-98D6-4411-A5F0-F928CBA64095}
+		{7274D8C3-EC9B-4D54-B472-CBE1E44C39AC} = {301F771F-CBE6-4D34-A24A-02F7DE5463DC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {961EEBAB-4149-4AA4-BEE7-9DAAE4C94133}

--- a/03-CoreGenerativeAITechniques/src/ReasoningLabs-01-SK/Program.cs
+++ b/03-CoreGenerativeAITechniques/src/ReasoningLabs-01-SK/Program.cs
@@ -1,0 +1,51 @@
+﻿#pragma warning disable SKEXP0010 // Reasoning effort is still in preview for OpenAI SDK.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.SemanticKernel.ChatCompletion;
+using Microsoft.SemanticKernel.Connectors.AzureOpenAI;
+using Microsoft.SemanticKernel.Connectors.OpenAI;
+
+// ==============================
+// Using Azure OpenAI models
+// ==============================
+//var deploymentName = Environment.GetEnvironmentVariable("AZURE_OPENAI_DEPLOYMENT");
+//var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT");
+//var apiKey = Environment.GetEnvironmentVariable("AZURE_OPENAI_APIKEY");
+//var modelId = Environment.GetEnvironmentVariable("AZURE_OPENAI_MODEL");
+//if (string.IsNullOrEmpty(endpoint))
+//{
+//    var config = new ConfigurationBuilder().AddUserSecrets<Program>().Build();
+//    deploymentName = config["AZURE_OPENAI_DEPLOYMENT"];
+//    endpoint = config["AZURE_OPENAI_ENDPOINT"];
+//    apiKey = config["AZURE_OPENAI_APIKEY"];
+//    modelId = config["AZURE_OPENAI_MODEL"];
+//}
+
+//// Initialize the OpenAI chat completion service with the o3-mini model.
+//var chatService = new AzureOpenAIChatCompletionService(
+//    deploymentName: deploymentName, 
+//    endpoint: endpoint,
+//    apiKey: apiKey,
+//    modelId: modelId
+//);
+
+// ==============================
+// Using OpenAI API directly
+// ==============================
+// Initialize the OpenAI chat completion service with the o3-mini model.
+var chatService = new OpenAIChatCompletionService(
+    modelId: "o3-mini",  // OpenAI API endpoint
+    apiKey: ""  // Your OpenAI API key
+);
+
+// Create a new chat history and add a user message to prompt the model.
+ChatHistory chatHistory = [];
+chatHistory.AddUserMessage("Why is the sky blue in one sentence?");
+
+// Configure reasoning effort for the chat completion request.
+var settings = new OpenAIPromptExecutionSettings { ReasoningEffort = "high" };
+
+// Send the chat completion request to o3-mini
+var reply = await chatService.GetChatMessageContentAsync(chatHistory, settings);
+Console.WriteLine("o3-mini reply: " + reply);
+

--- a/03-CoreGenerativeAITechniques/src/ReasoningLabs-01-SK/ReasoningLabs-01-SK.csproj
+++ b/03-CoreGenerativeAITechniques/src/ReasoningLabs-01-SK/ReasoningLabs-01-SK.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <RootNamespace>ReasoningLabs_01_SK</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UserSecretsId>585e845e-c369-447f-9e0b-de6c8b4e3a86</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.37.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
DETAILS
This pull request introduces a new project named `ReasoningLabs-01-SK` to the solution and includes initial implementation for using OpenAI's chat completion service. The most important changes include adding the new project to the solution, configuring the build settings, and implementing the initial code for the chat completion service.

### Addition of new project:
* Added `ReasoningLabs-01-SK` project to the solution file `03-CoreGenerativeAITechniques.sln` [[1]](diffhunk://#diff-27363b9e0973c3e94d2990d1e494ac20cefd25eeb908ff79a26dcc43e6d6feefR56-R59) [[2]](diffhunk://#diff-27363b9e0973c3e94d2990d1e494ac20cefd25eeb908ff79a26dcc43e6d6feefR142-R145) [[3]](diffhunk://#diff-27363b9e0973c3e94d2990d1e494ac20cefd25eeb908ff79a26dcc43e6d6feefR170).

### Build configuration:
* Created `ReasoningLabs-01-SK.csproj` with necessary configurations and package references.

### Initial implementation:
* Implemented initial code in `Program.cs` to use OpenAI's chat completion service with a sample prompt.
- Updated `CoreGenerativeAITechniques.sln` to include new projects: "07 Reasoning" and "ReasoningLabs-01-SK".
- Added `ReasoningLabs-01-SK.csproj` with .NET SDK and necessary package references.
- Refactored `Program.cs` to use OpenAI API directly, commenting out Azure OpenAI model initialization.

### Source Semantic Kernel Blog
[Using OpenAI’s o3-mini Reasoning Model in Semantic Kernel](https://devblogs.microsoft.com/semantic-kernel/using-openais-o3-mini-reasoning-model-in-semantic-kernel/)