### PR TITLE
Update SemanticKernel packages and console output

### DIFF
--- a/03-CoreGenerativeAITechniques/src/BasicChat-02SK/BasicChat-02SK.csproj
+++ b/03-CoreGenerativeAITechniques/src/BasicChat-02SK/BasicChat-02SK.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.2" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.37.0" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.38.0" />
 	  <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.2" />
   </ItemGroup>
 

--- a/03-CoreGenerativeAITechniques/src/BasicChat-04OllamaSK/BasicChat-04OllamaSK.csproj
+++ b/03-CoreGenerativeAITechniques/src/BasicChat-04OllamaSK/BasicChat-04OllamaSK.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.SemanticKernel" Version="1.37.0" />
+		<PackageReference Include="Microsoft.SemanticKernel" Version="1.38.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.2" />
-		<PackageReference Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.37.0-alpha" />
+		<PackageReference Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.38.0-alpha" />
 	</ItemGroup>
 
 </Project>

--- a/03-CoreGenerativeAITechniques/src/BasicChat-04OllamaSK/Program.cs
+++ b/03-CoreGenerativeAITechniques/src/BasicChat-04OllamaSK/Program.cs
@@ -28,7 +28,7 @@ while (true)
 
     var sb = new StringBuilder();
     var result = chat.GetStreamingChatMessageContentsAsync(history);
-    Console.Write("AI: ");
+    Console.Write($"AI [{modelId}]: ");
     await foreach (var item in result)
     {
         sb.Append(item);

--- a/03-CoreGenerativeAITechniques/src/RAGSimple-02MEAIVectorsMemory/RAGSimple-02MEAIVectorsMemory.csproj
+++ b/03-CoreGenerativeAITechniques/src/RAGSimple-02MEAIVectorsMemory/RAGSimple-02MEAIVectorsMemory.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.AI.Ollama" Version="9.3.0-preview.1.25114.11" />
     <PackageReference Include="Microsoft.Extensions.VectorData.Abstractions" Version="9.0.0-preview.1.25078.1" />
-    <PackageReference Include="Microsoft.SemanticKernel.Connectors.InMemory" Version="1.37.0-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.InMemory" Version="1.38.0-preview" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MEAIVectorsShared\MEAIVectorsShared.csproj" />

--- a/03-CoreGenerativeAITechniques/src/RAGSimple-03MEAIVectorsAISearch/RAGSimple-03MEAIVectorsAISearch.csproj
+++ b/03-CoreGenerativeAITechniques/src/RAGSimple-03MEAIVectorsAISearch/RAGSimple-03MEAIVectorsAISearch.csproj
@@ -13,7 +13,7 @@
 		<PackageReference Include="Microsoft.Extensions.AI.Ollama" Version="9.3.0-preview.1.25114.11" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.2" />
 		<PackageReference Include="Microsoft.Extensions.VectorData.Abstractions" Version="9.0.0-preview.1.25078.1" />
-		<PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureAISearch" Version="1.37.0-preview" />
+		<PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureAISearch" Version="1.38.0-preview" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/03-CoreGenerativeAITechniques/src/RAGSimple-04MEAIVectorsQdrant/RAGSimple-04MEAIVectorsQdrant.csproj
+++ b/03-CoreGenerativeAITechniques/src/RAGSimple-04MEAIVectorsQdrant/RAGSimple-04MEAIVectorsQdrant.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.AI.Ollama" Version="9.3.0-preview.1.25114.11" />
     <PackageReference Include="Microsoft.Extensions.VectorData.Abstractions" Version="9.0.0-preview.1.25078.1" />
-    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Qdrant" Version="1.37.0-preview" />
+    <PackageReference Include="Microsoft.SemanticKernel.Connectors.Qdrant" Version="1.38.0-preview" />
   </ItemGroup>
 
   <ItemGroup>

--- a/03-CoreGenerativeAITechniques/src/ReasoningLabs-01-SK/ReasoningLabs-01-SK.csproj
+++ b/03-CoreGenerativeAITechniques/src/ReasoningLabs-01-SK/ReasoningLabs-01-SK.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
-    <PackageReference Include="Microsoft.SemanticKernel" Version="1.37.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.2" />
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.38.0" />
   </ItemGroup>
 
 </Project>

--- a/03-CoreGenerativeAITechniques/src/SKFunctions01/SKFunctions01.csproj
+++ b/03-CoreGenerativeAITechniques/src/SKFunctions01/SKFunctions01.csproj
@@ -10,9 +10,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.2" />
-		<PackageReference Include="Microsoft.SemanticKernel" Version="1.37.0" />
+		<PackageReference Include="Microsoft.SemanticKernel" Version="1.38.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.2" />
-		<PackageReference Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.37.0-alpha" />
+		<PackageReference Include="Microsoft.SemanticKernel.Connectors.Ollama" Version="1.38.0-alpha" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
DETAILS

- Updated `Microsoft.SemanticKernel` to version `1.38.0` across multiple project files.
- Updated `Microsoft.SemanticKernel.Connectors.Ollama` to version `1.38.0-alpha`.
- Updated `Microsoft.SemanticKernel.Connectors.InMemory` to version `1.38.0-preview`.
- Updated `Microsoft.SemanticKernel.Connectors.AzureAISearch` to version `1.38.0-preview`.
- Updated `Microsoft.SemanticKernel.Connectors.Qdrant` to version `1.38.0-preview`.
- Upgraded `Microsoft.Extensions.Configuration.UserSecrets` to version `9.0.2`.
- Modified console output in `Program.cs` to include `modelId` in AI responses.