### PR TITLE
Update project to .NET 9.0 and package version

### DIFF
--- a/03-CoreGenerativeAITechniques/src/Vision-01MEAI-GitHubModels/Vision-01MEAI-GitHubModels.csproj
+++ b/03-CoreGenerativeAITechniques/src/Vision-01MEAI-GitHubModels/Vision-01MEAI-GitHubModels.csproj
@@ -1,37 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<RootNamespace>ConsoleMEAI_04_GitHubModels</RootNamespace>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<UserSecretsId>191519e3-ce5a-467f-bb4b-ace51d47e99c</UserSecretsId>
-	</PropertyGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.AI" Version="9.3.0-preview.1.25114.11">
-		  <TreatAsUsed>true</TreatAsUsed>
-		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.AI.AzureAIInference" Version="9.3.0-preview.1.25114.11" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.2" />
-		<PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20241108" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <Folder Include="images\" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<Content Include="..\images\german-receipt.jpg" Link="images\german-receipt.jpg">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="..\images\license.jpg" Link="images\license.jpg">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-		<Content Include="..\images\running-shoes.jpg" Link="images\running-shoes.jpg">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-	</ItemGroup>
-
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <RootNamespace>ConsoleMEAI_04_GitHubModels</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UserSecretsId>191519e3-ce5a-467f-bb4b-ace51d47e99c</UserSecretsId>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.AI" Version="9.3.0-preview.1.25114.11">
+      <TreatAsUsed>true</TreatAsUsed>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.AI.AzureAIInference" Version="9.3.0-preview.1.25114.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.3" />
+    <PackageReference Include="OpenCvSharp4.runtime.win" Version="4.10.0.20241108" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="images\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\images\german-receipt.jpg" Link="images\german-receipt.jpg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\images\license.jpg" Link="images\license.jpg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\images\running-shoes.jpg" Link="images\running-shoes.jpg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
DETAILS

Updated `Vision-01MEAI-GitHubModels.csproj` to target .NET 9.0, and upgraded `Microsoft.Extensions.Configuration.UserSecrets` from version 9.0.2 to 9.0.3. The project structure and included images remain unchanged.