### PR TITLE
Fix: correct improperly closed C# code block

### DIFF
--- a/translations/es/03-CoreGenerativeAITechniques/01-lm-completions-functions.md
+++ b/translations/es/03-CoreGenerativeAITechniques/01-lm-completions-functions.md
@@ -132,7 +132,7 @@ Hay algunos pasos de configuración que necesitas realizar para llamar funciones
         return $"The weather is {temperature} degrees C and {conditions}.";
     }
 
-```
+    ```
 
 2. Luego, vamos a crear un objeto `ChatOptions` que le indicará a MEAI qué funciones están disponibles.
 
@@ -143,7 +143,7 @@ Hay algunos pasos de configuración que necesitas realizar para llamar funciones
         Tools = [AIFunctionFactory.Create(GetTheWeather)]
     };
 
-```
+    ```
 
 3. Cuando instanciemos el objeto `IChatClient`, querremos especificar que usaremos invocación de funciones.
 


### PR DESCRIPTION
This PR fixes a formatting issue in one of the Markdown files where a C# code block was not properly closed. As a result, the paragraph was rendered as code. The issue has been corrected to improve readability and documentation clarity

Let me know if you'd like me to check other files for similar issues