### PR TITLE
Use GitHub Models in code

### DIFF
--- a/03-CoreGenerativeAITechniques/02-retrieval-augmented-generation.md
+++ b/03-CoreGenerativeAITechniques/02-retrieval-augmented-generation.md
@@ -84,11 +84,14 @@ We'll use the Microsoft.Extension.AI along with the [Microsoft.Extensions.Vector
 3. Our next task then is to convert our knowledge store (the `movieData` object) into embeddings and then store them into the in-memory vector store. When we create the embeddings we'll use a different model - an embeddings model instead of a language model.
 
     ```csharp
-    var endpoint = new Uri("https://models.inference.ai.azure.com");
-    var modelId = "text-embedding-3-small";
     // get embeddings generator and generate embeddings for movies
-    IEmbeddingGenerator<string, Embedding<float>> generator =
-        new OllamaEmbeddingGenerator(new Uri("http://localhost:11434/"), "all-minilm");
+    var githubToken = Environment.GetEnvironmentVariable("GITHUB_TOKEN") ?? throw new InvalidOperationException("GITHUB_TOKEN environment variable is not set.");
+    var endpoint = new Uri("https://models.inference.ai.azure.com");
+    var modelId = "text-embedding-3-small"; 
+
+    var embeddingsClient = new EmbeddingsClient(endpoint, new AzureKeyCredential(githubToken));
+    IEmbeddingGenerator<string, Embedding<float>> generator = embeddingsClient.AsIEmbeddingGenerator(modelId);
+
     foreach (var movie in movieData)
     {
         movie.Vector = await generator.GenerateVectorAsync(movie.Description);

--- a/03-CoreGenerativeAITechniques/src/RAGSimple-02MEAIVectorsMemory/RAGSimple-02MEAIVectorsMemory.csproj
+++ b/03-CoreGenerativeAITechniques/src/RAGSimple-02MEAIVectorsMemory/RAGSimple-02MEAIVectorsMemory.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.AI.Ollama" Version="9.5.0-preview.1.25265.7" />
+    <PackageReference Include="Microsoft.Extensions.AI.AzureAIInference" Version="9.5.0-preview.1.25265.7" />
     <PackageReference Include="Microsoft.Extensions.VectorData.Abstractions" Version="9.5.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Connectors.InMemory" Version="1.54.0-preview" />
   </ItemGroup>


### PR DESCRIPTION
The documentation suggests that the code is using GitHub Models, but the current implementation appears to rely on Ollama being present. This change updates the code to use GitHub Models.

Without this change, the existing code doesn't work on the regular "C# (.NET)" devcontainer and you need to use the "C# (.NET) - Ollama" as a workaround (which takes longer to load).

This is also a partial fix for #122 