### PR TITLE
Add BasicChat-07Ollama-gpt-oss project and initial implementation

### DIFF
--- a/03-CoreGenerativeAITechniques/src/BasicChat-07Ollama-gpt-oss/BasicChat-07Ollama-gpt-oss.csproj
+++ b/03-CoreGenerativeAITechniques/src/BasicChat-07Ollama-gpt-oss/BasicChat-07Ollama-gpt-oss.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net9.0</TargetFramework>
+		<RootNamespace>BasicChat_07Ollama_gpt_oss</RootNamespace>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.AI.Ollama" Version="9.5.0-preview.1.25265.7" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.7" />
+	</ItemGroup>
+
+</Project>

--- a/03-CoreGenerativeAITechniques/src/BasicChat-07Ollama-gpt-oss/Program.cs
+++ b/03-CoreGenerativeAITechniques/src/BasicChat-07Ollama-gpt-oss/Program.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Extensions.AI;
+using System.Text;
+
+// download the model from: https://ollama.com/library/gpt-oss:20b
+
+IChatClient client =
+    new OllamaChatClient(new Uri("http://localhost:11434/"), "gpt-oss:20b");
+
+// Prompt to test a reasoning model capability
+var prompt = new StringBuilder();
+prompt.AppendLine("You are a helpful assistant.");
+prompt.AppendLine("Answer the following question with a short explanation:");
+prompt.AppendLine("Why is the sky blue?");
+
+var response = await client.GetResponseAsync(prompt.ToString());
+
+Console.WriteLine(response.Text);

--- a/03-CoreGenerativeAITechniques/src/CoreGenerativeAITechniques.sln
+++ b/03-CoreGenerativeAITechniques/src/CoreGenerativeAITechniques.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.0.10829.221 main
+VisualStudioVersion = 18.0.10829.221
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BasicChat-01MEAI", "BasicChat-01MEAI\BasicChat-01MEAI.csproj", "{F924B9FC-D806-4350-BEC8-C0D4BB9E7C6D}"
 EndProject
@@ -106,6 +106,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MCP-02-HuggingFace-Ollama", "MCP-02-HuggingFace-Ollama\MCP-02-HuggingFace-Ollama.csproj", "{CB155DBA-0E2D-437D-AB29-FF5B65B44A27}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BasicChat-06OpenAIAPIs", "BasicChat-06OpenAIAPIs\BasicChat-06OpenAIAPIs.csproj", "{48371925-76C4-40BD-A6F4-95E983771191}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BasicChat-07Ollama-gpt-oss", "BasicChat-07Ollama-gpt-oss\BasicChat-07Ollama-gpt-oss.csproj", "{638B75D9-0314-4867-A75A-4E00046B8E27}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -573,6 +575,18 @@ Global
 		{48371925-76C4-40BD-A6F4-95E983771191}.Release|x64.Build.0 = Release|Any CPU
 		{48371925-76C4-40BD-A6F4-95E983771191}.Release|x86.ActiveCfg = Release|Any CPU
 		{48371925-76C4-40BD-A6F4-95E983771191}.Release|x86.Build.0 = Release|Any CPU
+		{638B75D9-0314-4867-A75A-4E00046B8E27}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{638B75D9-0314-4867-A75A-4E00046B8E27}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{638B75D9-0314-4867-A75A-4E00046B8E27}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{638B75D9-0314-4867-A75A-4E00046B8E27}.Debug|x64.Build.0 = Debug|Any CPU
+		{638B75D9-0314-4867-A75A-4E00046B8E27}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{638B75D9-0314-4867-A75A-4E00046B8E27}.Debug|x86.Build.0 = Debug|Any CPU
+		{638B75D9-0314-4867-A75A-4E00046B8E27}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{638B75D9-0314-4867-A75A-4E00046B8E27}.Release|Any CPU.Build.0 = Release|Any CPU
+		{638B75D9-0314-4867-A75A-4E00046B8E27}.Release|x64.ActiveCfg = Release|Any CPU
+		{638B75D9-0314-4867-A75A-4E00046B8E27}.Release|x64.Build.0 = Release|Any CPU
+		{638B75D9-0314-4867-A75A-4E00046B8E27}.Release|x86.ActiveCfg = Release|Any CPU
+		{638B75D9-0314-4867-A75A-4E00046B8E27}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -616,6 +630,7 @@ Global
 		{769320A2-CE09-41EF-A345-8BE6ABBE2696} = {3D13EC01-716A-41D9-BC54-1871EC14D3DE}
 		{CB155DBA-0E2D-437D-AB29-FF5B65B44A27} = {3D13EC01-716A-41D9-BC54-1871EC14D3DE}
 		{48371925-76C4-40BD-A6F4-95E983771191} = {1248F5FA-C7D6-4876-8313-A15A942F84FE}
+		{638B75D9-0314-4867-A75A-4E00046B8E27} = {1248F5FA-C7D6-4876-8313-A15A942F84FE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {961EEBAB-4149-4AA4-BEE7-9DAAE4C94133}

--- a/README.md
+++ b/README.md
@@ -28,18 +28,22 @@ Don't forget to [star (🌟) this repo](https://docs.github.com/en/get-started/e
 
 ➡️Get your own copy by [Forking this repo](https://github.com/microsoft/Generative-AI-for-beginners-dotnet/fork) and find it next in your own repositories.
 
-## ✨ What's New!
+## ✨ What's New
 
 We're constantly improving this course with the latest AI tools, models, and practical samples:
 
-- **🖼️ New! Hugging Face MCP Server Image Generation Samples!**
+- **� New! Basic Chat App for OpenAI gpt-oss Model!**
+
+  Try out our new [Basic Chat application](./03-CoreGenerativeAITechniques/src/BasicChat-07Ollama-gpt-oss) designed to test the [OpenAI gpt-oss model](https://openai.com/index/introducing-gpt-oss/). This sample demonstrates how to use the latest open-source model from OpenAI in a .NET console app, making it easy to experiment with conversational AI locally or in the cloud.
+
+- **🖼️ Hugging Face MCP Server Image Generation Samples!**
 
   Explore new C# console app samples that show how to use the Hugging Face MCP Server to generate images directly from your code.
 
   - [Try the sample using GitHub Models or Azure AI Foundry](./03-CoreGenerativeAITechniques/src/MCP-01-HuggingFace/Program.cs)
   - [Use Ollama for local model inference](./03-CoreGenerativeAITechniques/src/MCP-02-HuggingFace-Ollama/Program.cs)
 
-- **🕹️ New! Apps Generated with AI**
+- **🕹️ Apps Generated with AI**
 
   We're excited to introduce a new section featuring full applications generated with AI tools like GitHub Copilot Agent. These apps demonstrate how generative AI can be used to build real-world .NET solutions leveraging AI as a co-pilot.
 
@@ -87,7 +91,6 @@ You'll learn how to implement Generative AI into .NET projects, from basic text 
 | Portuguese           | pt   | [Portuguese Translation](./translations/pt/README.md)   | 2025-06-24   |
 | Spanish              | es   | [Spanish Translation](./translations/es/README.md)      | 2025-06-24   |
 | German               | de   | [German Translation](./translations/de/README.md)       | 2025-06-24   |
-
 
 > **Note:** All translations were updated to match the original content on **2025-06-24**. See [PR #161](https://github.com/microsoft/Generative-AI-for-beginners-dotnet/pull/161) for details.
 
@@ -142,7 +145,7 @@ We have a lot of other content to help your learning journey. Check out:
 - [AI Agents for Beginners - A Course](https://aka.ms/ai-agents-beginners)
 - [Data Science for Beginners](https://aka.ms/datascience-beginners)
 - [ML for Beginners](https://aka.ms/ml-beginners)
-- [Cybersecurity for Beginners](https://github.com/microsoft/Security-101) 
+- [Cybersecurity for Beginners](https://github.com/microsoft/Security-101)
 - [Web Dev for Beginners](https://aka.ms/webdev-beginners)
 - [IoT for Beginners](https://aka.ms/iot-beginners)
 - [XR Development for Beginners](https://github.com/microsoft/xr-development-for-beginners)


### PR DESCRIPTION
This pull request adds a new sample project demonstrating how to use the Ollama GPT-OSS model for basic chat functionality. The main changes include introducing the new project with its dependencies, implementing a simple chat client example, and updating the solution file to include and configure the new project.

**New project addition:**

* Added new project `BasicChat-07Ollama-gpt-oss` with references to `Microsoft.Extensions.AI.Ollama` and user secrets packages.
* Implemented a sample chat client in `Program.cs` that connects to a local Ollama instance using the `gpt-oss:20b` model and prints the model's response to a sample prompt.

**Solution file updates:**

* Registered the new project in the solution file and configured its build settings for all supported platforms and configurations. [[1]](diffhunk://#diff-27363b9e0973c3e94d2990d1e494ac20cefd25eeb908ff79a26dcc43e6d6feefR110-R111) [[2]](diffhunk://#diff-27363b9e0973c3e94d2990d1e494ac20cefd25eeb908ff79a26dcc43e6d6feefR578-R589) [[3]](diffhunk://#diff-27363b9e0973c3e94d2990d1e494ac20cefd25eeb908ff79a26dcc43e6d6feefR633)
* Minor formatting update to the solution file header.