### PR TITLE
Remove Aspire workload installation step

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -24,6 +24,3 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '9.0.x'
-
-      - name: Install Aspire workload
-        run: dotnet workload install aspire


### PR DESCRIPTION
Removed the step to install the Aspire workload in the workflow since Aspire is no longer installed as a workload.