### PR TITLE
docs: fix response comment typo

### DIFF
--- a/translations/de/03-CoreGenerativeAITechniques/01-lm-completions-functions.md
+++ b/translations/de/03-CoreGenerativeAITechniques/01-lm-completions-functions.md
@@ -40,7 +40,7 @@ prompt.AppendLine("I found this product based on the other reviews. It worked fo
 // send the prompt to the model and wait for the text completion
 var response = await client.GetResponseAsync(prompt.ToString());
 
-// display the repsonse
+// display the response
 Console.WriteLine(response.Message);
 
 ```

--- a/translations/es/03-CoreGenerativeAITechniques/01-lm-completions-functions.md
+++ b/translations/es/03-CoreGenerativeAITechniques/01-lm-completions-functions.md
@@ -40,7 +40,7 @@ prompt.AppendLine("I found this product based on the other reviews. It worked fo
 // send the prompt to the model and wait for the text completion
 var response = await client.GetResponseAsync(prompt.ToString());
 
-// display the repsonse
+// display the response
 Console.WriteLine(response.Message);
 
 ```

--- a/translations/fr/03-CoreGenerativeAITechniques/01-lm-completions-functions.md
+++ b/translations/fr/03-CoreGenerativeAITechniques/01-lm-completions-functions.md
@@ -40,7 +40,7 @@ prompt.AppendLine("I found this product based on the other reviews. It worked fo
 // send the prompt to the model and wait for the text completion
 var response = await client.GetResponseAsync(prompt.ToString());
 
-// display the repsonse
+// display the response
 Console.WriteLine(response.Message);
 
 ```

--- a/translations/ja/03-CoreGenerativeAITechniques/01-lm-completions-functions.md
+++ b/translations/ja/03-CoreGenerativeAITechniques/01-lm-completions-functions.md
@@ -40,7 +40,7 @@ prompt.AppendLine("I found this product based on the other reviews. It worked fo
 // send the prompt to the model and wait for the text completion
 var response = await client.GetResponseAsync(prompt.ToString());
 
-// display the repsonse
+// display the response
 Console.WriteLine(response.Message);
 
 ```

--- a/translations/ko/03-CoreGenerativeAITechniques/01-lm-completions-functions.md
+++ b/translations/ko/03-CoreGenerativeAITechniques/01-lm-completions-functions.md
@@ -40,7 +40,7 @@ prompt.AppendLine("I found this product based on the other reviews. It worked fo
 // send the prompt to the model and wait for the text completion
 var response = await client.GetResponseAsync(prompt.ToString());
 
-// display the repsonse
+// display the response
 Console.WriteLine(response.Message);
 
 ```

--- a/translations/pt/03-CoreGenerativeAITechniques/01-lm-completions-functions.md
+++ b/translations/pt/03-CoreGenerativeAITechniques/01-lm-completions-functions.md
@@ -39,7 +39,7 @@ prompt.AppendLine("I found this product based on the other reviews. It worked fo
 // send the prompt to the model and wait for the text completion
 var response = await client.GetResponseAsync(prompt.ToString());
 
-// display the repsonse
+// display the response
 Console.WriteLine(response.Message);
 
 ```

--- a/translations/tw/03-CoreGenerativeAITechniques/01-lm-completions-functions.md
+++ b/translations/tw/03-CoreGenerativeAITechniques/01-lm-completions-functions.md
@@ -40,7 +40,7 @@ prompt.AppendLine("I found this product based on the other reviews. It worked fo
 // send the prompt to the model and wait for the text completion
 var response = await client.GetResponseAsync(prompt.ToString());
 
-// display the repsonse
+// display the response
 Console.WriteLine(response.Message);
 
 ```

--- a/translations/zh/03-CoreGenerativeAITechniques/01-lm-completions-functions.md
+++ b/translations/zh/03-CoreGenerativeAITechniques/01-lm-completions-functions.md
@@ -40,7 +40,7 @@ prompt.AppendLine("I found this product based on the other reviews. It worked fo
 // send the prompt to the model and wait for the text completion
 var response = await client.GetResponseAsync(prompt.ToString());
 
-// display the repsonse
+// display the response
 Console.WriteLine(response.Message);
 
 ```


### PR DESCRIPTION
## Problem
Several translated lesson files contain the typo `repsonse` in a C# sample comment.

## Solution
Correct the comment to `response` in the matching translated lesson files.

## Validation
- `git diff --check`

Confidence score: 85/100
Category: docs/typo