### PR TITLE
 Fix: Resolve deployment RequestConflict race condition in main.bicep

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -52,6 +52,9 @@ module embedding 'modules/model-deployment-embedding.bicep' = {
     openAiServiceName: openAi.outputs.name
     location: location
   }
+  dependsOn: [
+    gpt5mini
+  ]
 }
 
 // Outputs for azd and downstream use


### PR DESCRIPTION
When running the initial setup script, deploying the chat and embedding models simultaneously caused a 409 RequestConflict error, adding the dependsOn array forces sequential deployment, resolving the lock issue.